### PR TITLE
Fix PiWind version

### DIFF
--- a/.github/workflows/install-test.yaml
+++ b/.github/workflows/install-test.yaml
@@ -30,4 +30,4 @@ jobs:
         pip install -r OasisPiWind/tests/requirements.in
 
     - name: run PiWind test
-      run: pytest OasisPiWind/tests/test_piwind_integration.py -v --use-running-containers --docker-compose=oasis-platform.yml
+      run: pytest OasisPiWind/tests/test_piwind_integration.py -v --use-running-containers --docker-compose=oasis-platform.yml -k ControlSet

--- a/.github/workflows/install-test.yaml
+++ b/.github/workflows/install-test.yaml
@@ -1,0 +1,33 @@
+name: Evaluation Installation Test
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+  workflow_dispatch:
+
+jobs:
+  install_test:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: run installation
+      run: ./install.sh
+
+    - name: Setup Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.10'
+
+    - name: install test deps
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r OasisPiWind/tests/requirements.in
+
+    - name: run PiWind test
+      run: pytest OasisPiWind/tests/test_piwind_integration.py -v --use-running-containers --docker-compose=oasis-platform.yml

--- a/oasis-platform.yml
+++ b/oasis-platform.yml
@@ -7,9 +7,6 @@ services:
   server:
    restart: always
    image: coreoasis/api_server:latest
-   build:
-     context: .
-     dockerfile: Dockerfile.api_server
    ports:
      - 8000:8000
    links:
@@ -70,9 +67,6 @@ services:
   worker:
     restart: always
     image: coreoasis/model_worker:latest
-    build:
-      context: .
-      dockerfile: Dockerfile.model_worker
     links:
      - celery-db
      - rabbit:myrabbit


### PR DESCRIPTION
### Fix installation script
The problem comes from using the PiWind repository tag `1.27.1`, which doesn't exist. 
Fixed by switching to the branch  `backports/1.27.x`, which is the version of piwind used for testing LTS releases based on patching `1.27.x`  

* Fixed Piwind git reference
* Added Github actions workflow to test for installation errors 

