### PR TITLE
Fix/sql support

### DIFF
--- a/oasis-platform.yml
+++ b/oasis-platform.yml
@@ -14,7 +14,7 @@ x-shared-env: &shared-env
   OASIS_SERVER_DB_PORT: 5432
   OASIS_SERVER_CHANNEL_LAYER_HOST: channel-layer
   OASIS_SERVER_DB_ENGINE: django.db.backends.postgresql
-  OASIS_CELERY_DB_ENGINE: db+postgresql+psycopg
+  OASIS_CELERY_DB_ENGINE: db+postgresql
   OASIS_CELERY_DB_HOST: celery-db
   OASIS_CELERY_DB_PASS: password
   OASIS_CELERY_DB_USER: celery
@@ -29,7 +29,7 @@ x-oasis-env-v1: &oasis-env-v1
   OASIS_RABBIT_PORT: 5672
   OASIS_RABBIT_USER: rabbit
   OASIS_RABBIT_PASS: rabbit
-  OASIS_CELERY_DB_ENGINE: db+postgresql+psycopg
+  OASIS_CELERY_DB_ENGINE: db+postgresql
   OASIS_CELERY_DB_HOST: celery-db
   OASIS_CELERY_DB_PASS: password
   OASIS_CELERY_DB_USER: celery

--- a/oasis-platform.yml
+++ b/oasis-platform.yml
@@ -13,8 +13,8 @@ x-shared-env: &shared-env
   OASIS_SERVER_DB_NAME: oasis
   OASIS_SERVER_DB_PORT: 5432
   OASIS_SERVER_CHANNEL_LAYER_HOST: channel-layer
-  OASIS_SERVER_DB_ENGINE: django.db.backends.postgresql_psycopg2
-  OASIS_CELERY_DB_ENGINE: db+postgresql+psycopg2
+  OASIS_SERVER_DB_ENGINE: django.db.backends.postgresql
+  OASIS_CELERY_DB_ENGINE: db+postgresql+psycopg
   OASIS_CELERY_DB_HOST: celery-db
   OASIS_CELERY_DB_PASS: password
   OASIS_CELERY_DB_USER: celery
@@ -29,7 +29,7 @@ x-oasis-env-v1: &oasis-env-v1
   OASIS_RABBIT_PORT: 5672
   OASIS_RABBIT_USER: rabbit
   OASIS_RABBIT_PASS: rabbit
-  OASIS_CELERY_DB_ENGINE: db+postgresql+psycopg2
+  OASIS_CELERY_DB_ENGINE: db+postgresql+psycopg
   OASIS_CELERY_DB_HOST: celery-db
   OASIS_CELERY_DB_PASS: password
   OASIS_CELERY_DB_USER: celery


### PR DESCRIPTION
Support both 'psycopg2' and 'psycopg3'  by removing the driver from the DB connection string