### PR TITLE
fix mountpoint for postress 18

### DIFF
--- a/oasis-platform.yml
+++ b/oasis-platform.yml
@@ -180,7 +180,7 @@ services:
       - POSTGRES_USER=oasis
       - POSTGRES_PASSWORD=oasis
     volumes:
-      - server-db-OasisData:/var/lib/postgresql/data:rw
+      - server-db-OasisData:/var/lib/postgresql:rw
     ports:
       - 33307:3306
   celery-db:
@@ -191,7 +191,7 @@ services:
       - POSTGRES_USER=celery
       - POSTGRES_PASSWORD=password
     volumes:
-      - celery-db-OasisData:/var/lib/postgresql/data:rw
+      - celery-db-OasisData:/var/lib/postgresql:rw
     ports:
       - 33306:5432
   broker:


### PR DESCRIPTION
new mount point is expected at `var/lib/postgresql` works both for v18 and v17 of posgres 